### PR TITLE
Multiplayer Support

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -162,6 +162,7 @@ bool GdbARM9BreakOnStartup;
 
 int MetroidAimSensitivity;
 int MetroidVirtualStylusSensitivity;
+int MetroidVsPlayerInput;
 
 CameraConfig Camera[2];
 
@@ -404,6 +405,7 @@ ConfigEntry ConfigFile[] =
 
     {"MetroidAimSensitivity", 0, &MetroidAimSensitivity, MetroidAimSensitivityDefault, false},
     {"MetroidVirtualStylusSensitivity", 0, &MetroidVirtualStylusSensitivity, MetroidVirtualStylusSensitivityDefault, false},
+    {"MetroidVsPlayerInput", 0, &MetroidVsPlayerInput, MetroidVsPlayerInputDefault, false},
 
     // TODO!!
     // we need a more elegant way to deal with this

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -236,9 +236,11 @@ extern bool GdbARM9BreakOnStartup;
 
 extern int MetroidAimSensitivity;
 extern int MetroidVirtualStylusSensitivity;
+extern int MetroidVsPlayerInput;
 
 const int MetroidAimSensitivityDefault = 30;
 const int MetroidVirtualStylusSensitivityDefault = 20;
+const int MetroidVsPlayerInputDefault = 1;
 
 void Load();
 void Save();

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -694,15 +694,16 @@ void EmuThread::run()
     #define FN_INPUT_PRESS(i) Input::InputMask.setBit(i, false);
     #define FN_INPUT_RELEASE(i) Input::InputMask.setBit(i, true);
 
+    melonDS::u32 aimXAddr;
+    melonDS::u32 aimYAddr;
+
 #define METROID_US_1_1 1
 #ifdef METROID_US_1_1
-    const melonDS::u32 aimXAddr = 0x020DEDA6;
-    const melonDS::u32 aimYAddr = 0x020DEDAE;
+    const bool metroidUSRev1 = true;
     const melonDS::u32 inBallAddr = 0x020DB098;
     const melonDS::u32 inVisorOrMapAddr = 0x020D9A7D; // my best guess
 #else
-    const melonDS::u32 aimXAddr = 0x020DE526;
-    const melonDS::u32 aimYAddr = 0x020DE52E;
+    const bool metroidUSRev1 = true;
     const melonDS::u32 inBallAddr = 0x020DA818;
 #endif
 
@@ -934,6 +935,46 @@ void EmuThread::run()
             // move
 
             processMoveInput();
+
+            // aim addresses for version and player number
+            if(metroidUSRev1) {
+                switch(Config::MetroidVsPlayerInput) {
+                    case 2:
+                        aimXAddr = 0x020DEDEE;
+                        aimYAddr = 0x020DEDF6;
+                        break;
+                    case 3:
+                        aimXAddr = 0x020DEE36;
+                        aimYAddr = 0x020DEE3E;
+                        break;
+                    case 4:
+                        aimXAddr = 0x020DEE7E;
+                        aimYAddr = 0x020DEE86;
+                        break;
+                    default:
+                        aimXAddr = 0x020DEDA6;
+                        aimYAddr = 0x020DEDAE;
+                }
+            }
+            else {
+                switch(Config::MetroidVsPlayerInput) {
+                    case 2:
+                        aimXAddr = 0x020DF66E;
+                        aimYAddr = 0x020DF676;
+                        break;
+                    case 3:
+                        aimXAddr = 0x020DF6B6;
+                        aimYAddr = 0x020DF6BE;
+                        break;
+                    case 4:
+                        aimXAddr = 0x020DF626;
+                        aimYAddr = 0x020DF706;
+                        break;
+                    default:
+                        aimXAddr = 0x020DE526;
+                        aimYAddr = 0x020DE52E;
+                }
+            }
 
             // cursor looking
             

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
@@ -94,6 +94,7 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
 
     ui->metroidAimSensitvitySpinBox->setValue(Config::MetroidAimSensitivity);
     ui->metroidVirtualStylusSensitvitySpinBox->setValue(Config::MetroidVirtualStylusSensitivity);
+	ui->metroidVsPlayerInputSpinBox->setValue(Config::MetroidVsPlayerInput);
 }
 
 void InputConfigDialog::switchTabToAddons() {
@@ -215,6 +216,7 @@ void InputConfigDialog::on_InputConfigDialog_accepted()
 
     Config::MetroidAimSensitivity = ui->metroidAimSensitvitySpinBox->value();
     Config::MetroidVirtualStylusSensitivity = ui->metroidVirtualStylusSensitvitySpinBox->value();
+	Config::MetroidVsPlayerInput = ui->metroidVsPlayerInputSpinBox->value();
 
     Config::Save();
 

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
@@ -2329,6 +2329,26 @@
          </property>
         </widget>
        </item>
+	   <item row="3" column="0">
+        <widget class="QLabel" name="metroidVsPlayerInputLabel">
+         <property name="text">
+          <string>Vs. mode player input:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QSpinBox" name="metroidVsPlayerInputSpinBox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>4</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
Tried to have a multiplayer match via the help of Kaeru WFC/Wiimmfi, and everything worked except for the fact that whoever was P2 wasn't able to aim, as well as their inputs instead spinning P1 from P2's POV until the incoming data rebounded P1 to where they were actually facing. 

Many hours later of trying to run the original DesMuME controller lua script in a match, I managed to figure out the memory addresses of P2's aim input, so I've created a simple setting for which player the client is supposed to be inputting to by changing the address the mouse data is being sent to depending on said setting. 

There are also values for P3 and P4 which I haven't been able to test in a real match without enough computers and VPNs, but watching near identical memory behavior and patterns for all 4 players no matter what mode would suggest they're correct.